### PR TITLE
fixed css reference inside adminController.js

### DIFF
--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -5,7 +5,7 @@ const db = require("../models");
 
 //Base route admin
 router.get("/", (req, res) => {
-    res.render("admin/index", { title: "Admin Page" });
+    res.render("admin/index", { title: "Admin Page", css: "main" });
 });
 
 module.exports = router;


### PR DESCRIPTION
hotfix for css reference inside adminController.js
when use render we need to populate these fields otherwise page would crash
title: " "
css: " " (css file name, do not include file type)
example:
`res.render("admin/index", { title: "Admin Page", css: "main" }); `